### PR TITLE
Add MkDocs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install MkDocs
+        run: |
+          pip install mkdocs mkdocs-material mkdocs-3d-model-viewer
+      - name: Deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy MkDocs site to gh-pages

## Testing
- `pip install -r requirements.txt` *(fails: ProxyError 403 Forbidden)*
- `pytest` *(no tests found)*
- `mkdocs build --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9b2525c48331aa3a207ed915fe6c